### PR TITLE
New script for reading URL's for the whole national filmography

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ in them.  With arguments `--movies` and `--persons` prints only those
 nodes.  Links from movies to directors, actors and characters are
 stored in the movie nodes, whereas the person nodes are quite empty.
 
+## `kf-filmurls.py`
+
+Reads the national filmography data from https://elonet.finna.fi/, and
+parses the pages for url links to Elonet database. List of url's is
+saved to file `kf-filmurls.txt`.
+
+The results of this could be used with `xml2rdf.py` but that script
+needs slight modifications before the data can be used.
+
 ## examples
 
 ```bash

--- a/kf-filmurls.py
+++ b/kf-filmurls.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python3
+
+import sys
+import argparse
+import requests
+import xml.etree.ElementTree as ET
+
+description=r"""Read list of films from the National Filmography
+
+Parses the elonet.finna.fi -rss feed and collects all film URL:s that refer to the Elonet database.
+
+The list of url's is printed to file 'kf-filmurls.txt'
+"""
+
+filmographyurl = "https://elonet.finna.fi/Search/Results?sort=main_date_str+asc&filter%5B%5D=%7Ebuilding%3A%221%2FKAVI%2Fskf%2F%22&type=AllFields&view=rss"
+
+parser = argparse.ArgumentParser(description=description)
+parser.add_argument('--debug',action="store_true",help="Print intermediate data to stdout")
+
+args = parser.parse_args()
+
+ns = {'atom':'http://www.w3.org/2005/Atom',
+      'dc':'http://purl.org/dc/elements/1.1/',
+      'slash':'http://purl.org/rss/1.0/modules/slash',
+      'opensearch':'http://a9.com/-/spec/opensearch/1.1/'}
+
+def parse_and_collect(url):
+    respage = requests.get(url).text
+    restree = ET.fromstring(respage)
+    reslist = restree.findall(".//item/link",ns)
+    if args.debug: print (list(map (lambda l: print (l.text),reslist)))
+    next = restree.findall(".//atom:link[@rel='next']",ns)
+    if (next):
+        if args.debug: print (next[0].attrib['href'])
+        return (reslist + parse_and_collect(next[0].attrib['href']))
+    else:
+        return (reslist)
+
+with open('kf-filmurls.txt','w') as of:
+    of.write("\n".join(list(map(lambda l: l.text,parse_and_collect(filmographyurl)))))


### PR DESCRIPTION
Hi,

added a new script that reads the urls for all 1602 films in the National Filmography and saves the urls to a file. This could be used as source for xml2rdf.py with some modification to that script.

the urls are parsed from the rss-feed provided but the Elonet database on page https://elonet.finna.fi/Search/Results?filter%5B%5D=%7Ebuilding%3A%221%2FKAVI%2Fskf%2F%22&type=AllFields&sort=main_date_str+asc

The script is quite small and should not be too complicated.

Harri